### PR TITLE
TestTranslate: Get tests working and implement first tests

### DIFF
--- a/Tests/Translate/CMakeLists.txt
+++ b/Tests/Translate/CMakeLists.txt
@@ -7,17 +7,23 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(CMAKE_CXX_FLAGS "-g -Wall -std=c++17 -Werror -D CMAKE_CXX_COMPILER=/usr/bin/g++-11")
 
-set(SRC TestTranslateInstructionToHexOpcode.cpp 
-        ../../src/Translate.h
-        ../../src/Translate.cpp
-        ../../src/OpCodes.cpp
-        ../../src/OpCodes.h
+set( TestFiles 
+    TestTranslateInstructionToHexOpcode.cpp
+    TestStandardizeInstruction.cpp
+   )
+
+set( SRC
+    ../../src/Translate.h 
+    ../../src/Translate.cpp 
+    ../../src/OpCodes.cpp 
+    ../../src/OpCodes.h 
    )
 
 find_package(Catch2 3 REQUIRED)
 
-add_executable(Tests ${SRC})
+add_executable(Tests ${SRC} ${TestFiles})
 
-include_directories("${CMAKE_SOURCE_DIR}/../../src/")
+include_directories("${CMAKE_SOURCE_DIR}/../../src/"
+                    "${CMAKE_SOURCE_DIR}/")
 
 target_link_libraries(Tests PRIVATE Catch2::Catch2WithMain)

--- a/Tests/Translate/TestStandardizeInstruction.cpp
+++ b/Tests/Translate/TestStandardizeInstruction.cpp
@@ -1,0 +1,8 @@
+#include <catch2/catch_test_macros.hpp>
+#include <Translate.h>
+
+TEST_CASE( "Standardize Instruction" ) {
+    Translate translate;
+
+    REQUIRE( translate.standardize_instruction({"LDA", "$4321", "X"}) == "LDA $XXXX X" );
+}

--- a/Tests/Translate/TestTranslateInstructionToHexOpcode.cpp
+++ b/Tests/Translate/TestTranslateInstructionToHexOpcode.cpp
@@ -1,9 +1,9 @@
 #include <catch2/catch_test_macros.hpp>
 #include <Translate.h>
 
-Translate translate;
-
 TEST_CASE( "Translate Instruction to Its OpCode in Hex" ) {
+    Translate translate;
+
     REQUIRE( translate.translate_instruction_to_hex_opcode("LDA $XX X") == 0xB5 );
     REQUIRE( translate.translate_instruction_to_hex_opcode("INX") == 0xE8 );
 }


### PR DESCRIPTION
So it begins. This is the initial commit for the Translate/ tests. The
CMakeLists.txt file works and we can run it and then make to compile
the tests into an executable. All this should be done in a script which
will get implemented soon. It should run test cases, then build the
system.

Added tests:
	Translate::standardize_instruction()
	Translate::translate_instruction_to_hex_opcode()

Each of those tests will need additional cases to get more code
coverage but this is a good start.