### PR TITLE
Everywhere: Add hexdump assemble flag

### DIFF
--- a/src/Assemble.cpp
+++ b/src/Assemble.cpp
@@ -37,6 +37,7 @@ int main(int argc, char* argv[]) {
     source_code.seekg(0);
 
     SymbolTable::m_program_counter = 1;
+    unsigned long long memory_address = 0x800;
 
     std::string buffer;
     while (std::getline(source_code, buffer)) {
@@ -59,7 +60,7 @@ int main(int argc, char* argv[]) {
         std::string binary_instruction_opcode = TranslationHelpers::decimal_to_binary(instruction_opcode);
 
         if (hexdump) {
-            std::cout << std::hex << "0x" << SymbolTable::m_program_counter << ": ";
+            std::cout << std::hex << "0x" << memory_address << ": ";
             std::cout << std::hex << instruction_opcode << " ";
         }
 
@@ -102,6 +103,7 @@ int main(int argc, char* argv[]) {
         }
 
         SymbolTable::m_program_counter++;
+        memory_address++;
 
     }
     

--- a/src/Assemble.cpp
+++ b/src/Assemble.cpp
@@ -44,7 +44,6 @@ int main(int argc, char* argv[]) {
 
         // Labels are already handled in earlier fill_symbol_table call
         if (SymbolTable::is_label(buffer)) {
-            SymbolTable::m_program_counter++;
             continue;
         }
 

--- a/src/Assemble.cpp
+++ b/src/Assemble.cpp
@@ -73,7 +73,7 @@ int main(int argc, char* argv[]) {
 
             // oper_low_byte and oper_high_byte return -1 if there is no oper
         
-            if (oper_low_byte > 0) {
+            if (oper_low_byte > 0 || (oper_low_byte >= 0 && oper_high_byte != -1)) {
                 std::string const oper_low_byte_binary = TranslationHelpers::decimal_to_binary(oper_low_byte);
                 executable << oper_low_byte_binary << std::endl;
                 if (hexdump)

--- a/src/Translate.cpp
+++ b/src/Translate.cpp
@@ -63,7 +63,7 @@ std::string Translate::standardize_instruction(std::vector<std::string> const& i
 int Translate::oper_low_byte(std::string const& oper) {
     size_t oper_length = oper.length();
 
-    if (oper_length < 2)
+    if (oper_length <= 2)
         return -1;
 
     std::string low_byte_string = oper.substr(oper_length-2, 2);


### PR DESCRIPTION
Can now pass an argument of "--hexdump" to the assembler. If argument
is passed the assembler prints to the console a hexdump of the provided
assembly file. This is useful for readability/usability purposes. In order to 
accommodate this change, a few other changes were made.
- Add memory_address variable which tracks memory starting at 0x800
- Fix some conditionals to act properly (bug fixes)
- Other small misc changes